### PR TITLE
Add Speech as an input mode. Also add auto layout constraints

### DIFF
--- a/Franklin.xcodeproj/project.pbxproj
+++ b/Franklin.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		1652F3E21E6601BB00E8DD20 /* ResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1652F3E11E6601BB00E8DD20 /* ResultsViewController.swift */; };
 		1652F3E41E66065400E8DD20 /* EyeCoverInstructionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1652F3E31E66065400E8DD20 /* EyeCoverInstructionViewController.swift */; };
 		16B6C2611E6BB77D00ECE02B /* SelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B6C2601E6BB77D00ECE02B /* SelectionViewController.swift */; };
+		E133D4651E6E231000A8AC9F /* SpeechManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E133D4641E6E231000A8AC9F /* SpeechManager.swift */; };
+		E133D4671E6E23CE00A8AC9F /* InputManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E133D4661E6E23CE00A8AC9F /* InputManagerDelegate.swift */; };
 		ED63FE721E649C3800467D7B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED63FE711E649C3800467D7B /* AppDelegate.swift */; };
 		ED63FE771E649C3800467D7B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED63FE751E649C3800467D7B /* Main.storyboard */; };
 		ED63FE791E649C3800467D7B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED63FE781E649C3800467D7B /* Assets.xcassets */; };
@@ -40,6 +42,8 @@
 		1652F3E11E6601BB00E8DD20 /* ResultsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultsViewController.swift; sourceTree = "<group>"; };
 		1652F3E31E66065400E8DD20 /* EyeCoverInstructionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EyeCoverInstructionViewController.swift; sourceTree = "<group>"; };
 		16B6C2601E6BB77D00ECE02B /* SelectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectionViewController.swift; sourceTree = "<group>"; };
+		E133D4641E6E231000A8AC9F /* SpeechManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpeechManager.swift; sourceTree = "<group>"; };
+		E133D4661E6E23CE00A8AC9F /* InputManagerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputManagerDelegate.swift; sourceTree = "<group>"; };
 		ED63FE6E1E649C3800467D7B /* Franklin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Franklin.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED63FE711E649C3800467D7B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		ED63FE761E649C3800467D7B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -112,6 +116,8 @@
 				1652F3E11E6601BB00E8DD20 /* ResultsViewController.swift */,
 				1652F3E31E66065400E8DD20 /* EyeCoverInstructionViewController.swift */,
 				16B6C2601E6BB77D00ECE02B /* SelectionViewController.swift */,
+				E133D4641E6E231000A8AC9F /* SpeechManager.swift */,
+				E133D4661E6E23CE00A8AC9F /* InputManagerDelegate.swift */,
 			);
 			path = Franklin;
 			sourceTree = "<group>";
@@ -202,7 +208,7 @@
 				TargetAttributes = {
 					ED63FE6D1E649C3800467D7B = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = 4XRLFC3F88;
+						DevelopmentTeam = 53T6WGJL5K;
 						ProvisioningStyle = Automatic;
 					};
 					ED63FE811E649C3800467D7B = {
@@ -272,8 +278,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				16B6C2611E6BB77D00ECE02B /* SelectionViewController.swift in Sources */,
+				E133D4651E6E231000A8AC9F /* SpeechManager.swift in Sources */,
 				ED63FE721E649C3800467D7B /* AppDelegate.swift in Sources */,
 				1652F3E41E66065400E8DD20 /* EyeCoverInstructionViewController.swift in Sources */,
+				E133D4671E6E23CE00A8AC9F /* InputManagerDelegate.swift in Sources */,
 				ED63FEA01E64A0D200467D7B /* ExamViewController.swift in Sources */,
 				1652F3E21E6601BB00E8DD20 /* ResultsViewController.swift in Sources */,
 			);
@@ -425,10 +433,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 4XRLFC3F88;
+				DEVELOPMENT_TEAM = 53T6WGJL5K;
 				INFOPLIST_FILE = Franklin/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.franklin.franklin-hci";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.franklin.franklin-hci-sergio";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
 			};
@@ -438,10 +446,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 4XRLFC3F88;
+				DEVELOPMENT_TEAM = 53T6WGJL5K;
 				INFOPLIST_FILE = Franklin/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.franklin.franklin-hci";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.franklin.franklin-hci-sergio";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
 			};

--- a/Franklin/Base.lproj/Main.storyboard
+++ b/Franklin/Base.lproj/Main.storyboard
@@ -1,11 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uni-55-pbt">
-    <device id="retina4_7" orientation="portrait">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C68" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uni-55-pbt">
+    <device id="retina5_5" orientation="landscape">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -21,10 +22,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hqL-Hr-u5g">
-                                <rect key="frame" x="61" y="261" width="545" height="94"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hqL-Hr-u5g">
+                                <rect key="frame" x="62" y="186" width="545" height="80"/>
                                 <color key="backgroundColor" red="0.1215686275" green="0.12941176469999999" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="80" id="Nut-0h-p7a"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="21"/>
                                 <state key="normal" title="Gesture">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -33,10 +36,12 @@
                                     <action selector="gestureVersionPressed:" destination="uni-55-pbt" eventType="touchUpInside" id="dwN-1f-j35"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AAl-zb-Tpq">
-                                <rect key="frame" x="61" y="149" width="545" height="94"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AAl-zb-Tpq">
+                                <rect key="frame" x="61" y="92" width="545" height="80"/>
                                 <color key="backgroundColor" red="0.1215686275" green="0.12941176469999999" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="80" id="Pbj-bA-DVF"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="21"/>
                                 <state key="normal" title="Button">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -45,33 +50,61 @@
                                     <action selector="buttonVersionPressed:" destination="uni-55-pbt" eventType="touchUpInside" id="UjA-Bn-d9R"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Franklin" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hqs-fm-vih">
-                                <rect key="frame" x="272" y="38" width="123" height="37"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Franklin" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hqs-fm-vih">
+                                <rect key="frame" x="278" y="12" width="112" height="41"/>
                                 <fontDescription key="fontDescription" name="Avenir-HeavyOblique" family="Avenir" pointSize="30"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="choose your form of input" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WlM-Qj-C4h">
-                                <rect key="frame" x="218" y="96" width="232" height="37"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="choose your form of input" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WlM-Qj-C4h">
+                                <rect key="frame" x="224" y="58" width="220" height="26"/>
                                 <fontDescription key="fontDescription" name="Avenir-BookOblique" family="Avenir" pointSize="19"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SWH-LK-qmT">
+                                <rect key="frame" x="62" y="280" width="545" height="80"/>
+                                <color key="backgroundColor" red="0.1215686275" green="0.12941176469999999" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="80" id="JZJ-4C-ASf"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="21"/>
+                                <state key="normal" title="Voice">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="voiceVersionPressed:" destination="uni-55-pbt" eventType="touchUpInside" id="TVq-Dr-SHY"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="SWH-LK-qmT" firstAttribute="leading" secondItem="MHT-F2-FMh" secondAttribute="leadingMargin" constant="42" id="05m-kp-OBa"/>
+                            <constraint firstItem="hqs-fm-vih" firstAttribute="top" secondItem="MHT-F2-FMh" secondAttribute="topMargin" constant="12" id="4Wd-rb-AVM"/>
+                            <constraint firstItem="AAl-zb-Tpq" firstAttribute="leading" secondItem="MHT-F2-FMh" secondAttribute="leadingMargin" constant="41" id="Hg9-ft-bHb"/>
+                            <constraint firstItem="SWH-LK-qmT" firstAttribute="top" secondItem="hqL-Hr-u5g" secondAttribute="bottom" constant="14" id="Imj-oc-ajw"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="AAl-zb-Tpq" secondAttribute="trailing" constant="41" id="Ly0-Su-BKI"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="hqL-Hr-u5g" secondAttribute="trailing" constant="40" id="O49-HH-h2O"/>
+                            <constraint firstItem="hqs-fm-vih" firstAttribute="centerX" secondItem="MHT-F2-FMh" secondAttribute="centerX" id="SVZ-wV-cwO"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="SWH-LK-qmT" secondAttribute="trailing" constant="40" id="Upo-sE-Xty"/>
+                            <constraint firstItem="AAl-zb-Tpq" firstAttribute="top" secondItem="WlM-Qj-C4h" secondAttribute="bottom" constant="8" id="YL4-Sn-gaA"/>
+                            <constraint firstItem="WlM-Qj-C4h" firstAttribute="top" secondItem="hqs-fm-vih" secondAttribute="bottom" constant="5" id="cpp-Ij-6nH"/>
+                            <constraint firstItem="hqL-Hr-u5g" firstAttribute="top" secondItem="AAl-zb-Tpq" secondAttribute="bottom" constant="14" id="ihk-wf-8co"/>
+                            <constraint firstItem="WlM-Qj-C4h" firstAttribute="centerX" secondItem="MHT-F2-FMh" secondAttribute="centerX" id="u3k-pj-F6D"/>
+                            <constraint firstItem="hqL-Hr-u5g" firstAttribute="leading" secondItem="MHT-F2-FMh" secondAttribute="leadingMargin" constant="42" id="yJD-l9-PHE"/>
+                        </constraints>
                     </view>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="667" height="375"/>
                     <connections>
                         <segue destination="Ypc-Ma-3OS" kind="presentation" identifier="gestureVersionChosen" id="gRI-gI-NPa"/>
                         <segue destination="Ypc-Ma-3OS" kind="presentation" identifier="buttonVersionChosen" id="V3y-Kb-Pgj"/>
+                        <segue destination="Ypc-Ma-3OS" kind="presentation" identifier="voiceVersionChosen" id="Piu-xX-Gm1"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="SX3-gX-P1R" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-852" y="-9.4452773613193415"/>
+            <point key="canvasLocation" x="-650" y="-313"/>
         </scene>
         <!--Exam View Controller-->
         <scene sceneID="ZkJ-c7-2Rh">
@@ -85,14 +118,36 @@
                         <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8M1-aB-gry">
-                                <rect key="frame" x="0.0" y="0.0" width="330" height="375"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ua1-EE-MM1">
+                                <rect key="frame" x="333.66666666666674" y="0.0" width="333.33333333333326" height="375"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ok9-CR-kXF">
-                                        <rect key="frame" x="100" y="0.0" width="130" height="114"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="c" translatesAutoresizingMaskIntoConstraints="NO" id="peg-f3-Cu2">
+                                        <rect key="frame" x="151.33333333333331" y="172.66666666666666" width="31" height="29"/>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yy7-eR-dgY">
+                                        <rect key="frame" x="139" y="335.66666666666674" width="55.999999999999943" height="31.333333333333314"/>
+                                        <fontDescription key="fontDescription" name="Avenir-BookOblique" family="Avenir" pointSize="23"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="peg-f3-Cu2" firstAttribute="centerY" secondItem="Ua1-EE-MM1" secondAttribute="centerY" id="A0d-46-r8f"/>
+                                    <constraint firstItem="peg-f3-Cu2" firstAttribute="centerX" secondItem="Ua1-EE-MM1" secondAttribute="centerX" id="Lbs-g7-VY4"/>
+                                    <constraint firstAttribute="bottom" secondItem="yy7-eR-dgY" secondAttribute="bottom" constant="8" id="R2c-ql-w7D"/>
+                                    <constraint firstItem="yy7-eR-dgY" firstAttribute="centerX" secondItem="Ua1-EE-MM1" secondAttribute="centerX" id="Vhj-d2-ets"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8M1-aB-gry">
+                                <rect key="frame" x="0.0" y="0.0" width="333.66666666666669" height="375"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ok9-CR-kXF">
+                                        <rect key="frame" x="102" y="0.0" width="130" height="114"/>
                                         <color key="backgroundColor" red="0.1215686275" green="0.12941176469999999" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="114" id="4N6-a4-Ddb"/>
+                                            <constraint firstAttribute="width" constant="130" id="fAw-yo-12m"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" name="Avenir-Heavy" family="Avenir" pointSize="21"/>
                                         <state key="normal" title="Up">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -101,22 +156,13 @@
                                             <action selector="upButtonPressed:" destination="Ypc-Ma-3OS" eventType="touchUpInside" id="7qj-eu-Jyg"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="jUK-LX-G2x">
-                                        <rect key="frame" x="100" y="122" width="130" height="130"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pnh-uY-REG">
+                                        <rect key="frame" x="8" y="123" width="85" height="129"/>
                                         <color key="backgroundColor" red="0.1215686275" green="0.12941176469999999" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="21"/>
-                                        <state key="normal" title="Not Sure">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="unsureButtonPressed:" destination="Ypc-Ma-3OS" eventType="touchUpInside" id="iOV-Fc-aRj"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pnh-uY-REG">
-                                        <rect key="frame" x="0.0" y="122" width="92" height="130"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" red="0.1215686275" green="0.12941176469999999" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="85" id="9Q2-Z4-4tq"/>
+                                            <constraint firstAttribute="height" constant="129" id="yS3-nh-HR2"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" name="Avenir-Heavy" family="Avenir" pointSize="21"/>
                                         <state key="normal" title="Left">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -125,10 +171,13 @@
                                             <action selector="leftButtonPressed:" destination="Ypc-Ma-3OS" eventType="touchUpInside" id="ykv-BN-3I4"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dEL-6q-keE">
-                                        <rect key="frame" x="238" y="122" width="92" height="130"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dEL-6q-keE">
+                                        <rect key="frame" x="238.66666666666669" y="122.66666666666669" width="87.000000000000057" height="130"/>
                                         <color key="backgroundColor" red="0.1215686275" green="0.12941176469999999" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="130" id="Hdq-c5-6xN"/>
+                                            <constraint firstAttribute="width" constant="87" id="Vph-oJ-8OO"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" name="Avenir-Heavy" family="Avenir" pointSize="21"/>
                                         <state key="normal" title="Right">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -137,10 +186,13 @@
                                             <action selector="rightButtonPressed:" destination="Ypc-Ma-3OS" eventType="touchUpInside" id="Eja-9X-YsO"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0GJ-xc-U4J">
-                                        <rect key="frame" x="100" y="260" width="130" height="115"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0GJ-xc-U4J">
+                                        <rect key="frame" x="102" y="257" width="130" height="118"/>
                                         <color key="backgroundColor" red="0.1215686275" green="0.12941176469999999" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="130" id="F9m-qd-eVf"/>
+                                            <constraint firstAttribute="height" constant="118" id="HYJ-6B-iqC"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" name="Avenir-Heavy" family="Avenir" pointSize="21"/>
                                         <state key="normal" title="Down">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -149,28 +201,56 @@
                                             <action selector="downButtonPressed:" destination="Ypc-Ma-3OS" eventType="touchUpInside" id="77l-N0-ct4"/>
                                         </connections>
                                     </button>
-                                </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                            </view>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ua1-EE-MM1">
-                                <rect key="frame" x="338" y="0.0" width="330" height="375"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="c" translatesAutoresizingMaskIntoConstraints="NO" id="peg-f3-Cu2">
-                                        <rect key="frame" x="91" y="118" width="140" height="138"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yy7-eR-dgY">
-                                        <rect key="frame" x="125" y="342" width="81" height="25"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <fontDescription key="fontDescription" name="Avenir-BookOblique" family="Avenir" pointSize="23"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Listening!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="50Y-le-y6M">
+                                        <rect key="frame" x="130" y="176" width="74" height="24"/>
+                                        <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="17"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="jUK-LX-G2x">
+                                        <rect key="frame" x="102" y="123.66666666666666" width="130" height="127.99999999999997"/>
+                                        <color key="backgroundColor" red="0.1215686275" green="0.12941176469999999" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="130" id="bV6-5O-3mT"/>
+                                            <constraint firstAttribute="height" constant="128" id="vyD-S7-aql"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="21"/>
+                                        <state key="normal" title="Not Sure">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="unsureButtonPressed:" destination="Ypc-Ma-3OS" eventType="touchUpInside" id="iOV-Fc-aRj"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="Pnh-uY-REG" firstAttribute="centerY" secondItem="8M1-aB-gry" secondAttribute="centerY" id="5hO-Wr-BzB"/>
+                                    <constraint firstItem="ok9-CR-kXF" firstAttribute="top" secondItem="8M1-aB-gry" secondAttribute="top" id="99N-J9-9iO"/>
+                                    <constraint firstItem="ok9-CR-kXF" firstAttribute="centerX" secondItem="8M1-aB-gry" secondAttribute="centerX" id="Dsf-4q-8vd"/>
+                                    <constraint firstItem="Pnh-uY-REG" firstAttribute="leading" secondItem="8M1-aB-gry" secondAttribute="leading" constant="8" id="PL0-sZ-8co"/>
+                                    <constraint firstItem="50Y-le-y6M" firstAttribute="centerX" secondItem="8M1-aB-gry" secondAttribute="centerX" id="XIL-to-FAc"/>
+                                    <constraint firstItem="jUK-LX-G2x" firstAttribute="centerX" secondItem="8M1-aB-gry" secondAttribute="centerX" id="ZHg-Dt-Zwc"/>
+                                    <constraint firstItem="0GJ-xc-U4J" firstAttribute="centerX" secondItem="8M1-aB-gry" secondAttribute="centerX" id="cOi-eH-kqr"/>
+                                    <constraint firstItem="dEL-6q-keE" firstAttribute="centerY" secondItem="8M1-aB-gry" secondAttribute="centerY" id="lVP-lG-o1P"/>
+                                    <constraint firstItem="50Y-le-y6M" firstAttribute="centerY" secondItem="8M1-aB-gry" secondAttribute="centerY" id="m5h-84-ynq"/>
+                                    <constraint firstAttribute="bottom" secondItem="0GJ-xc-U4J" secondAttribute="bottom" id="qQb-AK-zPD"/>
+                                    <constraint firstAttribute="trailing" secondItem="dEL-6q-keE" secondAttribute="trailing" constant="8" id="qn3-UM-jvv"/>
+                                    <constraint firstItem="jUK-LX-G2x" firstAttribute="centerY" secondItem="8M1-aB-gry" secondAttribute="centerY" id="wb3-Zb-6zB"/>
+                                </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="0.074020686490546828" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="trw-g1-qgG" firstAttribute="top" secondItem="8M1-aB-gry" secondAttribute="bottom" id="1DT-0g-FKd"/>
+                            <constraint firstAttribute="trailing" secondItem="Ua1-EE-MM1" secondAttribute="trailing" id="4hm-cf-L7I"/>
+                            <constraint firstItem="8M1-aB-gry" firstAttribute="leading" secondItem="e8u-cp-b82" secondAttribute="leading" id="6Af-Zh-FrA"/>
+                            <constraint firstItem="Ua1-EE-MM1" firstAttribute="leading" secondItem="8M1-aB-gry" secondAttribute="trailing" id="JGa-Eh-Jpd"/>
+                            <constraint firstItem="8M1-aB-gry" firstAttribute="top" secondItem="e8u-cp-b82" secondAttribute="top" id="btr-Nd-odJ"/>
+                            <constraint firstItem="Ua1-EE-MM1" firstAttribute="top" secondItem="e8u-cp-b82" secondAttribute="top" id="wzU-5x-Gdh"/>
+                            <constraint firstItem="Ua1-EE-MM1" firstAttribute="width" secondItem="8M1-aB-gry" secondAttribute="width" id="yPc-Jv-1br"/>
+                            <constraint firstItem="trw-g1-qgG" firstAttribute="top" secondItem="Ua1-EE-MM1" secondAttribute="bottom" id="zcx-I0-eKQ"/>
+                        </constraints>
                     </view>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="667" height="375"/>
@@ -179,6 +259,7 @@
                         <outlet property="directionLabel" destination="yy7-eR-dgY" id="XXU-Om-7CY"/>
                         <outlet property="downButton" destination="0GJ-xc-U4J" id="Egz-Ub-aeG"/>
                         <outlet property="examView" destination="Ua1-EE-MM1" id="m7f-Fx-R17"/>
+                        <outlet property="isListeningLabel" destination="50Y-le-y6M" id="IlX-Ue-QWv"/>
                         <outlet property="landoltC" destination="peg-f3-Cu2" id="tnr-tw-UGC"/>
                         <outlet property="leftButton" destination="Pnh-uY-REG" id="Qp6-kt-6gD"/>
                         <outlet property="rightButton" destination="dEL-6q-keE" id="3xX-OL-kzD"/>
@@ -190,7 +271,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="TD7-KY-kq1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="428" y="289"/>
+            <point key="canvasLocation" x="289" y="-2"/>
         </scene>
         <!--Eye Cover Instruction View Controller-->
         <scene sceneID="RWB-kN-I7D">
@@ -307,9 +388,9 @@ Now Testing Right Eye</string>
         </scene>
     </scenes>
     <resources>
-        <image name="c" width="47" height="44"/>
+        <image name="c" width="31" height="29"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="V3y-Kb-Pgj"/>
+        <segue reference="Piu-xX-Gm1"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Franklin/EyeCoverInstructionViewController.swift
+++ b/Franklin/EyeCoverInstructionViewController.swift
@@ -44,6 +44,9 @@ class EyeCoverInstructionViewController: UIViewController {
         nextController.inputType = self.inputType
         nextController.rightDone = self.rightDone
         nextController.leftDone = self.leftDone
+        
+        // Set the delegate on the singleton SpeechManager
+        SpeechManager.sharedInstance.inputDelegate = nextController
     }
     
 

--- a/Franklin/Info.plist
+++ b/Franklin/Info.plist
@@ -20,6 +20,10 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Your microphone will be used to record your speech when you start an Eye Examanation.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Speech recognition will be used to determine which words you speak into this device's microphone.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -31,7 +35,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>

--- a/Franklin/InputManagerDelegate.swift
+++ b/Franklin/InputManagerDelegate.swift
@@ -1,0 +1,19 @@
+//
+//  InputManagerType.swift
+//  Franklin
+//
+//  Created by Sergio Puleri on 3/6/17.
+//  Copyright © 2017 Franklin. All rights reserved.
+//
+
+import Foundation
+
+protocol InputManagerDelegate {
+    func left()
+    func right()
+    func down()
+    func up()
+    func unsure()
+    
+    func setIsReadyForInput(isReady: Bool)
+}

--- a/Franklin/SelectionViewController.swift
+++ b/Franklin/SelectionViewController.swift
@@ -29,17 +29,25 @@ class SelectionViewController: UIViewController {
         self.performSegue(withIdentifier: "gestureVersionChosen", sender: self)
     }
     
+    @IBAction func voiceVersionPressed(_ sender: Any) {
+        self.performSegue(withIdentifier: "voiceVersionChosen", sender: self)
+    }
     // MARK: - Navigation
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         // Get the new view controller using segue.destinationViewController.
         // Pass the selected object to the new view controller.
-          let nextController: ExamViewController = segue.destination as! ExamViewController
+        let nextController: ExamViewController = segue.destination as! ExamViewController
         if(segue.identifier == "buttonVersionChosen"){
             nextController.inputType = "button"
         } else if (segue.identifier == "gestureVersionChosen"){
             nextController.inputType = "gesture"
+        } else if (segue.identifier == "voiceVersionChosen"){
+            nextController.inputType = "voice"
+            
+            // Set the delegate on the singleton SpeechManager
+            SpeechManager.sharedInstance.inputDelegate = nextController
         }
     }
     

--- a/Franklin/SpeechManager.swift
+++ b/Franklin/SpeechManager.swift
@@ -1,0 +1,241 @@
+//
+//  SpeechManager.swift
+//  Franklin
+//
+//  Created by Sergio Puleri on 3/6/17.
+//  Copyright © 2017 Franklin. All rights reserved.
+//
+
+import Foundation
+import Speech
+
+
+class SpeechManager: NSObject, SFSpeechRecognizerDelegate {
+    // Singleton instance, so we don't need to bother passing it around through view controllers
+    static let sharedInstance = SpeechManager()
+
+    // Speech recognizer
+    private var speechRecognizer: SFSpeechRecognizer?
+    
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private let audioEngine = AVAudioEngine()
+    
+    // Bus number to install a tap on the inputNode on. This allows us to listen on the audio stream from the input device (mic)
+    let BUS_NUM = 0
+    
+    var inputDelegate: InputManagerDelegate?
+    
+    private override init() {
+        super.init()
+        
+        // Initialize recognizer to english
+        speechRecognizer = SFSpeechRecognizer(locale: Locale.init(identifier: "en-US"))
+        
+        // Set Delegate
+        speechRecognizer?.delegate = self
+    }
+    
+    func requestMicAccess() {
+        SFSpeechRecognizer.requestAuthorization { (authStatus) in
+            
+            var isButtonEnabled = false
+            
+            switch authStatus {
+            case .authorized:
+                print("We're good to go")
+                
+            case .denied:
+                print("User denied access to speech recognition")
+                
+            case .restricted:
+                isButtonEnabled = false
+                print("Speech recognition restricted on this device")
+                
+            case .notDetermined:
+                isButtonEnabled = false
+                print("Speech recognition not yet authorized")
+            }
+        }
+    }
+    
+    // Called by the view controller on each new step to stop/start session
+    func startRecordingSesion() {
+        if audioEngine.isRunning {
+            print("audioEngine is running when attemping to start recording.")
+        }
+        
+        stopProcessing()
+        
+        startRecording()
+        // Denote we are listening
+        inputDelegate?.setIsReadyForInput(isReady: true)
+        
+    }
+    
+    func stopRecordingSession() {
+        stopProcessing()
+    }
+    
+    private func stopProcessing() {
+        if let inputNode = audioEngine.inputNode {
+            inputNode.removeTap(onBus: self.BUS_NUM)
+        }
+        
+        self.audioEngine.stop()
+        
+        recognitionRequest?.endAudio()
+        self.recognitionTask?.cancel()
+        self.recognitionRequest = nil
+        self.recognitionTask = nil
+    }
+    
+    // Recording and Speech Transcribing Logic
+    private func startRecording() {
+        // Cancel an inprogress recognition task
+        if recognitionTask != nil {
+            recognitionTask?.cancel()
+            recognitionTask = nil
+        }
+        
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setCategory(AVAudioSessionCategoryRecord)
+            try audioSession.setMode(AVAudioSessionModeMeasurement)
+            try audioSession.setActive(true, with: .notifyOthersOnDeactivation)
+        } catch {
+            print("audioSession properties weren't set because of an error.")
+        }
+        
+        // New recognition request
+        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+        
+        
+        // Unwrap all the optional objects hehe
+        guard let inputNode = audioEngine.inputNode else {
+            fatalError("Audio engine has no input node")
+        }
+        
+        guard let recognitionRequest = recognitionRequest else {
+            fatalError("Unable to create an SFSpeechAudioBufferRecognitionRequest object")
+        }
+        
+        guard let speechRecognizer = speechRecognizer else {
+            fatalError("Unable to create an SFSpeechRecognizer object")
+        }
+        
+        recognitionRequest.shouldReportPartialResults = true
+        
+        // Start the recognition task
+        recognitionTask = speechRecognizer.recognitionTask(with: recognitionRequest, resultHandler: { (result, error) in
+            
+            var commandHandler: (() -> ())? = nil
+            
+            if let result = result {
+                let spokenText = result.bestTranscription.formattedString
+                print("Got some words:\n\(spokenText)\n\n")
+                
+                commandHandler = self.processUsersAnswer(spokenText: spokenText)
+                // If we get some text and it is a valid 'left' 'right' 'up' or 'down', stop this recording session
+            }
+            
+            // If there was an error recognizing the voice OR this transcription is final, stop recording for now
+            if error != nil || commandHandler != nil {
+                if let error = error {
+                    // See: https://forums.developer.apple.com/thread/73256
+                    print("Got an error processing speech... We should be gucci tho!\n\(error)\n")
+                }
+                
+                if let handler = commandHandler {
+                    // Show case something on the screen to denote if recording or not
+                    self.inputDelegate?.setIsReadyForInput(isReady: false)
+                    handler()
+                }
+            }
+        })
+        
+        let recordingFormat = inputNode.outputFormat(forBus: BUS_NUM)
+        inputNode.installTap(onBus: BUS_NUM, bufferSize: 1024, format: recordingFormat) { (buffer, when) in
+            self.recognitionRequest?.append(buffer)
+        }
+        
+        audioEngine.prepare()
+        
+        do {
+            try audioEngine.start()
+        } catch {
+            print("audioEngine couldn't start because of an error.")
+        }
+        
+        // Update view to denote listening
+        self.inputDelegate?.setIsReadyForInput(isReady: true)
+        print("Say something, I'm listening!")        
+    }
+    
+
+    // Processes text looking for a valid phrase
+    // Returns an optional closure to execute to notify the ExamViewController if found a valid phrase command
+    // Else returns nil.
+    // A closure is returned instead of just calling the function because we need to check if a valid phrase was found
+    // To stop recording. THEN notify the ExamViewController of this command. Which will then progress the test to the next step.
+    
+    // TODO: If multiple phrases are found, take the last one
+    private func processUsersAnswer(spokenText: String) -> (() -> ())? {
+        // Lowercase the transcribed text
+        let lowerCase = spokenText.lowercased()
+        
+        // Process  with string searching
+        if lowerCase.contains("left") {
+            print("Parsed left from speech")
+            
+            return {
+                self.inputDelegate?.left()
+            }
+        }
+        else if lowerCase.contains("right") {
+            print("Parsed right from speech")
+            
+            return {
+                self.inputDelegate?.right()
+            }
+        }
+        else if lowerCase.contains("up") {
+            print("Parsed up from speech")
+            
+            return {
+                self.inputDelegate?.up()
+            }
+        }
+        else if lowerCase.contains("down") {
+            print("Parsed down from speech")
+            
+            return {
+                self.inputDelegate?.down()
+            }
+        }
+        // TODO: Configure with more 'unsure' phrases if necessary
+        else if lowerCase.contains("i don't know") ||
+            lowerCase.contains("not sure") ||
+            lowerCase.contains("unsure") ||
+            lowerCase.contains("no"){
+            
+            print("Parsed unsure from speech")
+            return {
+                self.inputDelegate?.unsure()
+            }
+            
+        } else {
+            print("Got no valid commands from speech")
+            return nil
+        }
+    }
+    
+    // MARK: SFSpeechRecognizerDelegate
+    func speechRecognizer(_ speechRecognizer: SFSpeechRecognizer, availabilityDidChange available: Bool) {
+        if available {
+            // TODO: Alert VC that we are good to go
+        } else {
+            // TODO: Alert VC that we are NOT good to go, stop exam
+        }
+    }
+}


### PR DESCRIPTION
- Add Speech input mode using Apple's new [Speech framework](https://developer.apple.com/reference/speech) introduced in iOS10
- Add autolayout constraints to Selection View and Exam View
  - There are some annoying issues i couldn't figure out at this time with awkward margins [(screenshot)](https://cloud.githubusercontent.com/assets/7324023/23718175/821f7566-0404-11e7-8775-4458f82ff50b.png) and overlapping views [(screenshot)](https://cloud.githubusercontent.com/assets/7324023/23718174/821f0086-0404-11e7-9670-41e623cee1bc.png).
  - Also, the image size might be a little different with constraints. We might need to fiddle with the image @takashiw 



closes #9 